### PR TITLE
Add hint for local build to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,6 @@ Rendered output is available on [Read the Docs](https://horizon-eda.readthedocs.
 If applicable, try to follow the [Google Developer Documentation Style 
 Guide](https://developers.google.com/style/).
 
+To build the documentation locally make sure you have python-sphinx installed and run `make html`
+
 This repository is licensed under CC-BY-SA-4.0.


### PR DESCRIPTION
I added a short pointer that should help people building the documentation locally.