### PR TITLE
Make Debian installation directions multiarch-compatible

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -41,7 +41,7 @@ See the `directory listing <https://mirror.selfnet.de/horizon-eda/>`__ for the l
 
 ::
 
- deb [signed-by=/usr/local/share/keyrings/horizon-eda-debian.gpg] https://mirror.selfnet.de/horizon-eda/<distro>-<release>/ <release> main
+ deb [signed-by=/usr/local/share/keyrings/horizon-eda-debian.gpg, arch=amd64] https://mirror.selfnet.de/horizon-eda/<distro>-<release>/ <release> main
 
 
 ::


### PR DESCRIPTION
I have other architectures enabled, which makes `apt update` produce errors if I just follow the instructions. Looks like there are only packages for amd64 anyways, so it's easy to tell apt to only use this source for amd64.