### PR TITLE
Building on Linux: add cppzmq, podofo-0.9 to arch linux dependencies

### DIFF
--- a/build-linux.rst
+++ b/build-linux.rst
@@ -41,8 +41,8 @@ On Arch Linux:
 
 ::
 
-   sudo pacman -S zeromq gtkmm3 cairomm librsvg sqlite3 libgit2 curl \
-        opencascade boost glm podofo libarchive libspnav
+   sudo pacman -S zeromq cppzmq gtkmm3 cairomm librsvg sqlite3 libgit2 curl \
+        opencascade boost glm podofo-0.9 libarchive libspnav
 
 On Fedora:
 


### PR DESCRIPTION
Arch seems to have split cppzmq headers from the zeromq package. It is also packaging pdoofo 0.10 as the default, which comes with [many breaking changes](https://github.com/podofo/podofo/wiki/PoDoFo-API-migration-guide/#098---0100)